### PR TITLE
Set RTD to use the sphinx htmlzip instead of the single zip

### DIFF
--- a/robotpy_sphinx/all.py
+++ b/robotpy_sphinx/all.py
@@ -8,3 +8,4 @@ def setup(app):
 
     app.setup_extension(pybind11_fixer.__name__)
     app.setup_extension("sphinx_automodapi.smart_resolver")
+    app.setup_extension(rtd_patch.__name__)

--- a/robotpy_sphinx/rtd_patch.py
+++ b/robotpy_sphinx/rtd_patch.py
@@ -1,0 +1,14 @@
+# Force RTD to build zip with regular html builder, not single html
+# The builder is preloaded after all extensions are loaded, so we can
+# change the registered class here.
+
+from sphinx.builders.html import StandaloneHTMLBuilder
+from sphinx.application import Sphinx
+
+
+class ReadtheDocsBuilderLocalMedia(StandaloneHTMLBuilder):
+    name = "readthedocssinglehtmllocalmedia"
+
+
+def setup(app):
+    app.add_builder(ReadtheDocsBuilderLocalMedia, override=True)


### PR DESCRIPTION
Credit for rtd_patch.py goes to @TheTripleV from https://github.com/wpilibsuite/frc-docs/blob/main/source/_extensions/rtd_patch.py Adapted to remove the photofinish part